### PR TITLE
Fix docusaurus editUrl link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,7 +96,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl: "https://github.com/spruceid/",
+          editUrl: "https://github.com/spruceid/spruceid.dev/edit/main/",
           remarkPlugins: [remarkImportPartial],
         },
         blog: {


### PR DESCRIPTION
The current `Edit this page` link in the docs is broken. If you click it (for example, on the docs homepage), it takes you here: https://github.com/spruceid/docs/homepage.md

When it ought to take you here: https://github.com/spruceid/spruceid.dev/edit/main/docs/homepage.md

This PR aims to fix that.