### PR TITLE
Update credible/install.sh Java install code snippet

### DIFF
--- a/docs/credible/install.md
+++ b/docs/credible/install.md
@@ -31,8 +31,8 @@ manage your Rust installation.
 On Ubuntu you could run:
 
 ```bash
-# apt update
-# apt install openjdk-8-jdk
+$ sudo apt update
+$ sudo apt install openjdk-8-jdk
 ```
 
 For more information, please refer to the documentation of your favorite flavour


### PR DESCRIPTION
The other commands begin with `$`, but here we use `#`, so for consistency I've propose changing it to also use `$`. Additionally, other `apt install` commands on this page assume non-root user and thus begin with `sudo`, so I've updated this line to do the same.