### PR TITLE
Fix incorrectly ordered commands

### DIFF
--- a/docs/didkit/install.md
+++ b/docs/didkit/install.md
@@ -23,8 +23,7 @@ Spruce's [ssi][] library must be cloned alongside the `didkit` repository in a p
 
 ```sh
 mkdir didkit
-git clone https://github.com/spruceid/didkit
-cd didkit
+git clone https://github.com/spruceid/didkit && cd didkit
 git clone https://github.com/spruceid/ssi ../ssi --recurse-submodules
 ```
 

--- a/docs/didkit/install.md
+++ b/docs/didkit/install.md
@@ -22,16 +22,16 @@ We do not depend on any Rust nightly features, so our installation instructions 
 Spruce's [ssi][] library must be cloned alongside the `didkit` repository in a parallel directory between downloading didkit and building it.
 
 ```sh
-$ mkdir didkit
-$ cd didkit
-$ git clone https://github.com/spruceid/didkit
-$ git clone https://github.com/spruceid/ssi ../ssi --recurse-submodules
+mkdir didkit
+git clone https://github.com/spruceid/didkit
+cd didkit
+git clone https://github.com/spruceid/ssi ../ssi --recurse-submodules
 ```
 
 Build DIDKit using [Cargo][], from root directory of DIDKit project:
 
 ```sh
-$ cargo build
+cargo build
 ```
 
 This will give you the DIDKit CLI and HTTP server executables located at

--- a/docs/didkit/intro.md
+++ b/docs/didkit/intro.md
@@ -42,22 +42,22 @@ Prerequisites:
 Building `didkit` :
 
 ```sh
-$ git clone https://github.com/spruceid/ssi --recurse-submodules
-$ git clone https://github.com/spruceid/didkit
-$ cd didkit/
-$ cargo build
+git clone https://github.com/spruceid/ssi --recurse-submodules
+git clone https://github.com/spruceid/didkit
+cd didkit/
+cargo build
 ```
 
 That's it-- you're not ready to use `didkit`'s CLI. For comprehensive documentation of CLI commands, see [Github](https://github.com/spruceid/didkit/tree/main/cli), and for a more skimmable overview, see the [CLI page](/docs/didkit-packages/cli_commands)) here.  For example, these basic commands should confirm the installation was succesful:
 
 ```sh
-$ ./target/debug/didkit -h
-$ ./target/debug/didkit generate-ed25519-key > key.jwk
+./target/debug/didkit -h
+./target/debug/didkit generate-ed25519-key > key.jwk
 ```
 
 You're also ready to spin up a `didkit`-powered HTTP server for internal or external use, depending on your context. For comprehensive documentation of the HTTP commands, see [Github ](https://github.com/spruceid/didkit/tree/main/http), and for a more skimmable overview, see the [HTTP page](/docs/didkit-packages/http_syntax) here. The HTTP server can be spun up with a single command if passed a key and some flags, and will respond with the port on which it will listen for valid calls:
 
-```sh
+```bash
 $ ./target/debug/didkit-http -k key.jwk
 Listening on http://127.0.0.1:51467/
 ```


### PR DESCRIPTION
Super minor, but we need to add another `cd` command here to be in the right directory. So this PR adds that (and some other tiny changes)