### PR TITLE
Make Jwk filename consistent in shell instructions

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -56,7 +56,7 @@ loaded via filepath.
 
 ```sh
 didkit generate-ed25519-key > issuer_key.jwk
-issuer_did=$(didkit key-to-did key -k key.jwk)
+issuer_did=$(didkit key-to-did key -k issuer_key.jwk)
 echo $issuer_did
 ```
 


### PR DESCRIPTION
Small fix. Also adds a newline before EOF (per being on Linux), but I don't think that should be a problem.