### PR TITLE
Hotfix/didkit cli docs

### DIFF
--- a/docs/didkit-examples/core-functions-in-bash.md
+++ b/docs/didkit-examples/core-functions-in-bash.md
@@ -191,143 +191,257 @@ cat presentation-verify-result.json | jq .
 echo Done
 ```
 
-### Appendix: whole script without comments
+### Appendix: whole script without commentary
 
-Also available on Github as
+The following is a stand-alone version of all of the above, also available on
+Github as
 [/cli/tests/example.sh](https://github.com/spruceid/didkit/blob/main/cli/tests/example.sh)
 
 ```bash
 #!/bin/sh
 # This is an example shell script using DIDKit for key generation,
-# credential/presentation issuance and verification. Run it in the
-# directory where didkit-cli has been built.
-# `jq` is an optional bash tool for displaying JSON objects legibly.
-# if desired, install with `sudo apt-get install jq`; otherwise, 
-# substitute all `cat $file | jq .` commands for a text editor
-# like `nano`  or `vim`.
+# credential/presentation issuance and verification.
+
+# Exit if any command in the script fails.
 set -e
 
+# Allow issuing using a DID method other than did:key
+did_method=${DID_METHOD:-key}
+# More info about did:key: https://w3c-ccg.github.io/did-method-key/
+
+# Allow setting proof format using environmental variables.
+proof_format=${PROOF_FORMAT:-ldp}
+vc_proof_format=${VC_PROOF_FORMAT:-$proof_format}
+vp_proof_format=${VP_PROOF_FORMAT:-$proof_format}
+
+# Pretty-print JSON using jq or json_pp if available.
 print_json() {
-    file=${1?file}
-    if command -v jq >/dev/null 2>&1; then
-        jq . "$file" || cat "$file"
-    elif command -v json_pp >/dev/null 2>&1; then
-        json_pp < "$file" || cat "$file"
-    else
-        cat "$file"
-    fi
+	file=${1?file}
+	if command -v jq >/dev/null 2>&1; then
+		jq . "$file" || cat "$file"
+	elif command -v json_pp >/dev/null 2>&1; then
+		json_pp < "$file" || cat "$file"
+	else
+		cat "$file"
+	fi
 }
 
+# Run the rest of this script in its source directory.
 cd "$(dirname "$0")"
 
+# Build the didkit CLI program
 cargo build -p didkit-cli
 
-export PATH=$PWD/../../target/debug:$PATH
+# Adjust $PATH to include the didkit executable.
+export PATH="$PWD/../../target/debug:$PATH"
 
-# check for issuer key and generate verification method to match
-
-if [ -e issuer_key.jwk ]; then
-    echo 'Using existing keypair.'
+# Create a ed25119 keypair if needed.
+if [ -e key.jwk ]; then
+	echo 'Using existing keypair.'
 else
-    didkit generate-ed25519-key > issuer_key.jwk
-    echo 'Generated keypair.'
+	didkit generate-ed25519-key > key.jwk
+	echo 'Generated keypair.'
 fi
 echo
 
-did=$(didkit key-to-did-key -k issuer_key.jwk)
+# Get the keypair's DID.
+did=$(didkit key-to-did "$did_method" -k key.jwk)
 printf 'DID: %s\n\n' "$did"
 
-issuer_verification_method=$(didkit key-to-verification-method -k issuer_key.jwk)
-printf 'issuer verificationMethod: %s\n\n' "$issuer_verification_method"
+# Get verificationMethod for keypair.
+# This is used to identify the key in linked data proofs.
+verification_method=$(didkit key-to-verification-method "$did_method" -k key.jwk)
+printf 'verificationMethod: %s\n\n' "$verification_method"
 
+# Prepare credential for issuing.
+# In this example credential, the issuance date, id, and credential subject id
+# are arbitrary. For more info about what these properties mean, see the
+# Verifiable Credentials Data Model: https://w3c.github.io/vc-data-model/
 cat > credential-unsigned.jsonld <<EOF
 {
-    "@context": "https://www.w3.org/2018/credentials/v1",
-    "id": "http://example.org/credentials/3731",
-    "type": ["VerifiableCredential"],
-    "issuer": "$did",
-    "issuanceDate": "2020-08-19T21:41:50Z",
-    "credentialSubject": {
-        "id": "did:example:d23dd687a7dc6787646f2eb98d0"
-    }
+	"@context": "https://www.w3.org/2018/credentials/v1",
+	"id": "http://example.org/credentials/3731",
+	"type": ["VerifiableCredential"],
+	"issuer": "$did",
+	"issuanceDate": "2020-08-19T21:41:50Z",
+	"credentialSubject": {
+		"id": "did:example:d23dd687a7dc6787646f2eb98d0"
+	}
 }
 EOF
 
+# Issue the verifiable credential.
+# Ask didkit to issue a verifiable credential using the given keypair file,
+# verification method, and proof purpose, passing the unsigned credential on
+# standard input. DIDKit creates a linked data proof to add to the credential,
+# and outputs the resulting newly-issued verifiable credential on standard
+# output, which we save to a file.
 didkit vc-issue-credential \
-    -k issuer_key.jwk \
-    -v "$verification_method" \
-    -p assertionMethod \
-    < credential-unsigned.jsonld \
-    > credential-signed.jsonld
+	-k key.jwk \
+	-v "$verification_method" \
+	-p assertionMethod \
+	-f "$vc_proof_format" \
+	< credential-unsigned.jsonld \
+	> credential-signed
 echo 'Issued verifiable credential:'
-print_json credential-signed.jsonld
+if [ "$vc_proof_format" = jwt ]; then
+	cat credential-signed
+else
+	print_json credential-signed
+fi
 echo
 
+# Verify verifiable credential.
+# We pass the newly-issued verifiable credential back to didkit for
+# verification using the given verification method and proof purpose. DIDKit
+# outputs the verification result as JSON. If verification is successful, the
+# command completes successfully (returns exit code 0).
 if ! didkit vc-verify-credential \
-    -v "$verification_method" \
-    -p assertionMethod \
-    < credential-signed.jsonld \
-    > credential-verify-result.json
+	-v "$verification_method" \
+	-p assertionMethod \
+	-f "$vc_proof_format" \
+	< credential-signed \
+	> credential-verify-result.json
 then
-    echo 'Unable to verify credential:'
-    print_json credential-verify-result.json
-    exit 1
+	echo 'Unable to verify credential:'
+	print_json credential-verify-result.json
+	exit 1
 fi
 echo 'Verified verifiable credential:'
 print_json credential-verify-result.json
 echo
 
-# check for holder key and generate verification method to match,
-# for creating verifiable presentation
-
-if [ -e holder_key.jwk ]; then
-    echo 'Using existing keypair.'
+# Encode credential as JSON for presenting.
+if [ "$vc_proof_format" = jwt ]; then
+	echo -n '"'
+	cat credential-signed
+	echo -n '"'
 else
-    didkit generate-ed25519-key > holder_key.jwk
-    echo 'Generated keypair.'
-fi
-echo
+	cat credential-signed
+fi > credential-signed.json
 
-# generate DID of using method DID:key from holder key
-
-did=$(didkit key-to-did-key -k holder_key.jwk)
-printf 'DID: %s\n\n' "$did"
-
-holder_verification_method=$(didkit key-to-verification-method -k holder_key.jwk)
-printf 'holder verificationMethod: %s\n\n' "$holder_verification_method"
-
+# Create presentation embedding verifiable credential.
+# Prepare to present the verifiable credential by wrapping it in a
+# Verifiable Presentation. The id here is an arbitrary URL for example purposes.
 cat > presentation-unsigned.jsonld <<EOF
 {
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
-    "id": "http://example.org/presentations/3731",
-    "type": ["VerifiablePresentation"],
-    "holder": "$did",
-    "verifiableCredential": $(cat credential-signed.jsonld)
+	"@context": ["https://www.w3.org/2018/credentials/v1"],
+	"id": "http://example.org/presentations/3731",
+	"type": ["VerifiablePresentation"],
+	"holder": "$did",
+	"verifiableCredential": $(cat credential-signed.json)
 }
 EOF
 
+# Issue verifiable presentation.
+# Pass the unsigned verifiable presentation to didkit to be issued as a
+# verifiable presentation. DIDKit signs the presentation with a linked data
+# proof, using the given keypair, verification method and proof type. We save
+# the resulting newly created verifiable presentation to a file.
 didkit vc-issue-presentation \
-    -k holder_key.jwk \
-    -v "$verification_method" \
-    -p authentication \
-    < presentation-unsigned.jsonld \
-    > presentation-signed.jsonld
+	-k key.jwk \
+	-v "$verification_method" \
+	-p authentication \
+	-f "$vp_proof_format" \
+	< presentation-unsigned.jsonld \
+	> presentation-signed
 echo 'Issued verifiable presentation:'
-print_json presentation-signed.jsonld
+if [ "$vp_proof_format" = jwt ]; then
+	cat presentation-signed
+else
+	print_json presentation-signed
+fi
 echo
 
+# Verify verifiable presentation.
+# Pass the verifiable presentation back to didkit for verification.
+# Examine the verification result JSON.
 if ! didkit vc-verify-presentation \
-    -v "$verification_method" \
-    -p authentication \
-    < presentation-signed.jsonld \
-    > presentation-verify-result.json
+	-v "$verification_method" \
+	-p authentication \
+	-f "$vp_proof_format" \
+	< presentation-signed \
+	> presentation-verify-result.json
 then
-    echo 'Unable to verify presentation:'
-    print_json presentation-verify-result.json
-    exit 1
+	echo 'Unable to verify presentation:'
+	print_json presentation-verify-result.json
+	exit 1
 fi
 echo 'Verified verifiable presentation:'
 print_json presentation-verify-result.json
+echo
+
+# Resolve a DID.
+if ! didkit did-resolve "$did" > did.json
+then
+	echo 'Unable to resolve DID.'
+	exit 1
+fi
+echo 'Resolved DID to DID document:'
+print_json did.json
+
+# Dereference a DID URL
+if ! didkit did-dereference "$verification_method" > vm.json
+then
+	echo 'Unable to dereference DID URL.'
+	exit 1
+fi
+echo 'Dereferenced DID URL for verification method:'
+print_json vm.json
+
+# Authenticate with a DID
+if ! challenge=$(awk 'BEGIN { srand(); print rand() }')
+then
+	echo 'Unable to create challenge.'
+	exit 1
+fi
+if ! didkit did-auth \
+	-k key.jwk \
+	-h "$did" \
+	-p authentication \
+	-C "$challenge" \
+	-v "$verification_method" \
+	-f "$vp_proof_format" \
+	> auth
+then
+	echo 'Unable to create DIDAuth response'
+	exit 1
+fi
+
+echo 'Generated DIDAuth verifiable presentation:'
+if [ "$vp_proof_format" = jwt ]; then
+	cat auth
+else
+	print_json auth
+fi
+echo
+
+# Verify DID auth
+if ! didkit vc-verify-presentation \
+	-p authentication \
+	-C "$challenge" \
+	-f "$vp_proof_format" \
+	< auth \
+	> auth-verify-result.json
+then
+	echo 'Unable to verify DIDAuth presentation:'
+	print_json auth-verify-result.json
+	exit 1
+fi
+echo 'Verified DIDAuth verifiable presentation:'
+print_json auth-verify-result.json
+echo
+
+# Convert VP to Canonicalized RDF
+if [ "$vp_proof_format" = ldp ]; then
+	if ! didkit to-rdf-urdna2015 < auth > auth.nq
+	then
+		echo 'Unable to convert/canonicalize document:' >&2
+		exit 1
+	fi
+	echo 'Converted verifiable presentation to canonicalized N-Quads:'
+	cat auth.nq
+fi
 echo
 
 echo Done

--- a/docs/didkit-examples/core-functions-in-bash.md
+++ b/docs/didkit-examples/core-functions-in-bash.md
@@ -5,13 +5,25 @@ title: Core Functions (CLI)
 
 ## Introduction
 
-This is an example shell script using all the core functions of DIDKit-CLI: key generation, credential/presentation issuance and verification.
+This is an example shell script using all the core functions of DIDKit-CLI: key
+generation, credential/presentation issuance and verification.
 
-_Note: This script is meant to be in a DIDKit-CLI source directory. See the complete script below for setup details._
+### Setup
+
+_Note: This script is meant to be run in the directory where DIDKit-CLI is
+built, regardless of installation method. See the complete script below for
+setup details._
+
+1. These instructions assume Ubuntu, and have been tested on Linux, MacOS, and
+   WSL2.
+1. See DIDKit installation page instructions for dependencies and install options.
+1. `jq` is recommended but not required for testing purposes. It can be
+   installed by running the command `sudo apt-get install jq`.
 
 ### Start with a keypair
 
-DIDKit can generate a unique ed25119 keypair from entropy. Alternately, you can provide a static key locally.
+DIDKit can generate a unique ed25119 keypair from entropy. Alternately, you can
+provide a static key locally.
 
 ```bash
 if [ -e issuer_key.jwk ]; then
@@ -26,7 +38,11 @@ echo
 
 ### Generate a DID:Key document
 
-This document gets wrapped around the keypair generated (or passed) in the previous step. For more context on the DID:key method, see the [specification](https://w3c-ccg.github.io/did-method-key/).
+This document gets wrapped around the keypair generated (or passed) in the
+previous step. For more context on the DID:key method, see the
+[specification](https://w3c-ccg.github.io/did-method-key/). For more info on the
+parameters and flags for the `key-to-did` function, run `didkit help
+key-to-did`.
 
 ```bash
 did=$(didkit key-to-did key -k issuer_key.jwk)
@@ -35,11 +51,13 @@ printf 'DID: %s\n\n' "$did"
 
 ### Define verificationMethod for keypair.
 
-This is used to identify the key in linked data proofs. Verifiers of such proofs query a DID found in a credential based on what [registered] proof type (i.e., what kind of signatures) it needs key material to verify.
+This is used to identify the key in linked data proofs. Verifiers of such proofs
+query a DID found in a credential based on what [registered] proof type (i.e.,
+what kind of signatures) it needs key material to verify.
 
 ```bash
-verification_method=$(didkit key-to-verification-method -k issuer_key.jwk)
-printf 'verificationMethod: %s\n\n' "$verification_method"
+issuer_verification_method=$(didkit key-to-verification-method key -k issuer_key.jwk)
+printf 'verificationMethod: %s\n\n' "$issuer_verification_method"
 ```
 
 ### Prepare credential for issuing.
@@ -56,9 +74,9 @@ i.e., "urn:uuid:", etc.
 
 ```bash
 SUBJECTDID='did:example:d23dd687a7dc6787646f2eb98d0'
-ISSUERDID='did:web:issuance.example.com'
+ISSUERDID=$did
 DATE=`date --utc +%FT%TZ`
-CREDID=`uuidgen`
+CREDID="urn:uuid:"`uuidgen`
 
 cat > credential-unsigned.jsonld <<EOF
 {
@@ -68,7 +86,7 @@ cat > credential-unsigned.jsonld <<EOF
 	"issuer": "$ISSUERDID",
 	"issuanceDate": "$DATE",
 	"credentialSubject": {
-		"id": "$SUBJECTID"
+		"id": "$SUBJECTDID"
 	}
 }
 EOF
@@ -83,13 +101,12 @@ EOF
 ```bash
 didkit vc-issue-credential \
 	-k issuer_key.jwk \
-	-v "$verification_method" \
+	-v "$issuer_verification_method" \
 	-p assertionMethod \
 	< credential-unsigned.jsonld \
 	> credential-signed.jsonld
 echo 'Issued verifiable credential:'
-print_json credential-signed.jsonld
-echo
+cat credential-signed.jsonld | jq .
 ```
 
 ### Verify a verifiable credential.
@@ -100,7 +117,7 @@ echo
 
 ```bash
 if ! didkit vc-verify-credential \
-	-v "$verification_method" \
+	-v "$issuer_verification_method" \
 	-p assertionMethod \
 	< credential-signed.jsonld \
 	> credential-verify-result.json
@@ -110,8 +127,7 @@ then
 	exit 1
 fi
 echo 'Verified verifiable credential:'
-print_json credential-verify-result.json
-echo
+cat credential-verify-result.json | jq .
 ```
 
 ### Create a verifiable presentation that embeds the verifiable credential.
@@ -151,8 +167,7 @@ didkit vc-issue-presentation \
 	< presentation-unsigned.jsonld \
 	> presentation-signed.jsonld
 echo 'Issued verifiable presentation:'
-print_json presentation-signed.jsonld
-echo
+cat presentation-signed.jsonld | jq .
 ```
 
 ### Verify the verifiable presentation.
@@ -161,7 +176,7 @@ echo
 
 ```bash
 if ! didkit vc-verify-presentation \
-	-v "$verification_method" \
+	-v "$issuer_verification_method" \
 	-p authentication \
 	< presentation-signed.jsonld \
 	> presentation-verify-result.json
@@ -171,8 +186,7 @@ then
 	exit 1
 fi
 echo 'Verified verifiable presentation:'
-print_json presentation-verify-result.json
-echo
+cat presentation-verify-result.json | jq .
 
 echo Done
 ```
@@ -185,19 +199,23 @@ Also available on Github as
 ```bash
 #!/bin/sh
 # This is an example shell script using DIDKit for key generation,
-# credential/presentation issuance and verification.
-
+# credential/presentation issuance and verification. Run it in the
+# directory where didkit-cli has been built.
+# `jq` is an optional bash tool for displaying JSON objects legibly.
+# if desired, install with `sudo apt-get install jq`; otherwise, 
+# substitute all `cat $file | jq .` commands for a text editor
+# like `nano`  or `vim`.
 set -e
 
 print_json() {
-	file=${1?file}
-	if command -v jq >/dev/null 2>&1; then
-		jq . "$file" || cat "$file"
-	elif command -v json_pp >/dev/null 2>&1; then
-		json_pp < "$file" || cat "$file"
-	else
-		cat "$file"
-	fi
+    file=${1?file}
+    if command -v jq >/dev/null 2>&1; then
+        jq . "$file" || cat "$file"
+    elif command -v json_pp >/dev/null 2>&1; then
+        json_pp < "$file" || cat "$file"
+    else
+        cat "$file"
+    fi
 }
 
 cd "$(dirname "$0")"
@@ -209,10 +227,10 @@ export PATH=$PWD/../../target/debug:$PATH
 # check for issuer key and generate verification method to match
 
 if [ -e issuer_key.jwk ]; then
-	echo 'Using existing keypair.'
+    echo 'Using existing keypair.'
 else
-	didkit generate-ed25519-key > issuer_key.jwk
-	echo 'Generated keypair.'
+    didkit generate-ed25519-key > issuer_key.jwk
+    echo 'Generated keypair.'
 fi
 echo
 
@@ -224,36 +242,36 @@ printf 'issuer verificationMethod: %s\n\n' "$issuer_verification_method"
 
 cat > credential-unsigned.jsonld <<EOF
 {
-	"@context": "https://www.w3.org/2018/credentials/v1",
-	"id": "http://example.org/credentials/3731",
-	"type": ["VerifiableCredential"],
-	"issuer": "$did",
-	"issuanceDate": "2020-08-19T21:41:50Z",
-	"credentialSubject": {
-		"id": "did:example:d23dd687a7dc6787646f2eb98d0"
-	}
+    "@context": "https://www.w3.org/2018/credentials/v1",
+    "id": "http://example.org/credentials/3731",
+    "type": ["VerifiableCredential"],
+    "issuer": "$did",
+    "issuanceDate": "2020-08-19T21:41:50Z",
+    "credentialSubject": {
+        "id": "did:example:d23dd687a7dc6787646f2eb98d0"
+    }
 }
 EOF
 
 didkit vc-issue-credential \
-	-k issuer_key.jwk \
-	-v "$verification_method" \
-	-p assertionMethod \
-	< credential-unsigned.jsonld \
-	> credential-signed.jsonld
+    -k issuer_key.jwk \
+    -v "$verification_method" \
+    -p assertionMethod \
+    < credential-unsigned.jsonld \
+    > credential-signed.jsonld
 echo 'Issued verifiable credential:'
 print_json credential-signed.jsonld
 echo
 
 if ! didkit vc-verify-credential \
-	-v "$verification_method" \
-	-p assertionMethod \
-	< credential-signed.jsonld \
-	> credential-verify-result.json
+    -v "$verification_method" \
+    -p assertionMethod \
+    < credential-signed.jsonld \
+    > credential-verify-result.json
 then
-	echo 'Unable to verify credential:'
-	print_json credential-verify-result.json
-	exit 1
+    echo 'Unable to verify credential:'
+    print_json credential-verify-result.json
+    exit 1
 fi
 echo 'Verified verifiable credential:'
 print_json credential-verify-result.json
@@ -263,10 +281,10 @@ echo
 # for creating verifiable presentation
 
 if [ -e holder_key.jwk ]; then
-	echo 'Using existing keypair.'
+    echo 'Using existing keypair.'
 else
-	didkit generate-ed25519-key > holder_key.jwk
-	echo 'Generated keypair.'
+    didkit generate-ed25519-key > holder_key.jwk
+    echo 'Generated keypair.'
 fi
 echo
 
@@ -280,33 +298,33 @@ printf 'holder verificationMethod: %s\n\n' "$holder_verification_method"
 
 cat > presentation-unsigned.jsonld <<EOF
 {
-	"@context": ["https://www.w3.org/2018/credentials/v1"],
-	"id": "http://example.org/presentations/3731",
-	"type": ["VerifiablePresentation"],
-	"holder": "$did",
-	"verifiableCredential": $(cat credential-signed.jsonld)
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "id": "http://example.org/presentations/3731",
+    "type": ["VerifiablePresentation"],
+    "holder": "$did",
+    "verifiableCredential": $(cat credential-signed.jsonld)
 }
 EOF
 
 didkit vc-issue-presentation \
-	-k holder_key.jwk \
-	-v "$verification_method" \
-	-p authentication \
-	< presentation-unsigned.jsonld \
-	> presentation-signed.jsonld
+    -k holder_key.jwk \
+    -v "$verification_method" \
+    -p authentication \
+    < presentation-unsigned.jsonld \
+    > presentation-signed.jsonld
 echo 'Issued verifiable presentation:'
 print_json presentation-signed.jsonld
 echo
 
 if ! didkit vc-verify-presentation \
-	-v "$verification_method" \
-	-p authentication \
-	< presentation-signed.jsonld \
-	> presentation-verify-result.json
+    -v "$verification_method" \
+    -p authentication \
+    < presentation-signed.jsonld \
+    > presentation-verify-result.json
 then
-	echo 'Unable to verify presentation:'
-	print_json presentation-verify-result.json
-	exit 1
+    echo 'Unable to verify presentation:'
+    print_json presentation-verify-result.json
+    exit 1
 fi
 echo 'Verified verifiable presentation:'
 print_json presentation-verify-result.json

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -127,7 +127,7 @@ curl https://demo.spruceid.com/get-example-vc > example-vc.json
 ```
 
 <details>
-  <summary>`example-vc.json` should resemble the following content:</summary>
+  <summary>`example-vc.json` should resemble the following content (click to expand):</summary>
   <div>
      <code>{`
 {


### PR DESCRIPTION
As per user email earlier today. /docs/didkit-examples/core-functions-in-bash.md had falled behind the source script (/didkit/cli/tests/example.sh) and had missed a breaking change to syntax.