### PR TITLE
Minor bug in instructions

### DIFF
--- a/docs/didkit-examples/core-functions-in-bash.md
+++ b/docs/didkit-examples/core-functions-in-bash.md
@@ -162,7 +162,7 @@ In these examples, the keys representing the two parties are stored in expressiv
 ```bash
 didkit vc-issue-presentation \
 	-k issuer_key.jwk \
-	-v "$verification_method" \
+	-v "$issuer_verification_method" \
 	-p authentication \
 	< presentation-unsigned.jsonld \
 	> presentation-signed.jsonld


### PR DESCRIPTION
There is a discrepancy between $verification_method and $issuer_verification_method. Although I notice in the appendix you use $verification_method.

I was also a bit confused by the note:

`In these examples, the keys representing the two parties are stored in expressive filenames, 'issuer_key' and 'holder_key'. There are, however, no differences between these keys, and the JWK filenames were chosen simply to clarify the example; there are no restrictions on them.`

referring to holder_key when that does not appear in the text. Perhaps would be clearer to refactor to have a holder key and use that did as the id of the credental rather using dummy data for the credential subject.

Pretty cool kit though!